### PR TITLE
refactor: update keycloak dependency to version 24.7.5 and adjust ser…

### DIFF
--- a/charts/launchpad/Chart.lock
+++ b/charts/launchpad/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: mlops-keycloak
-  repository: oci://ghcr.io/neuro-inc/helm-charts
-  version: 25.8.0-dev.15
+- name: keycloak
+  repository: https://charts.bitnami.com/bitnami
+  version: 24.7.5
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.7.19
-digest: sha256:8a2a69bf5f44c7d4065f09924dc34f10024cab4a76f3f66ad9b81494ac87f64b
-generated: "2025-08-21T14:27:16.512560918-03:00"
+digest: sha256:1896d14bb6a20986f6afe06f07d3a83afe3142b1d4fdffbde7e575eb7174c068
+generated: "2025-08-22T11:49:10.684501119-03:00"

--- a/charts/launchpad/Chart.yaml
+++ b/charts/launchpad/Chart.yaml
@@ -5,9 +5,9 @@ kubeVersion: ">= 1.19.0-0"
 version: 1.0.0
 appVersion: 1.0.0
 dependencies:
-  - name: mlops-keycloak
-    version: "25.8.0-dev.15"
-    repository: "oci://ghcr.io/neuro-inc/helm-charts"
+  - name: keycloak
+    version: "24.7.5"
+    repository: "https://charts.bitnami.com/bitnami"
   - name: postgresql
     version: "16.7.19"
     repository: "https://charts.bitnami.com/bitnami"

--- a/charts/launchpad/values.yaml
+++ b/charts/launchpad/values.yaml
@@ -104,7 +104,5 @@ keycloak:
     - effect: NoSchedule              
       key: platform.neuromation.io/job
       operator: Exists
-  service:
-    extraLabels: {}
-    headless:
-      extraLabels: {}
+  commonLabels:
+    service: keycloak


### PR DESCRIPTION
…vice labels


Reverting to using keycloak chart because the newer version I based my fork on has some different config. I believe we can achieve the same with adding a commonLabel to all keycloak objects. We might get an issue getting the service in outputs because keycloak exposes 2 services (and our logic simply gets the first one), but let's see