### PR TITLE
add sync-wave annotations to deployment and ingress resources

### DIFF
--- a/charts/launchpad/templates/deployment-launchpad.yaml
+++ b/charts/launchpad/templates/deployment-launchpad.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "launchpad.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   replicas: {{ .Values.replicas }}
   selector:

--- a/charts/launchpad/templates/ingress-client.yaml
+++ b/charts/launchpad/templates/ingress-client.yaml
@@ -2,6 +2,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "launchpad.name" . }}-client
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   labels:
     {{- include "launchpad.labels" . | nindent 4 }}
     service: client

--- a/charts/launchpad/templates/ingress-keycloak.yaml
+++ b/charts/launchpad/templates/ingress-keycloak.yaml
@@ -2,6 +2,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "launchpad.name" . }}-keycloak
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   labels:
     {{- include "launchpad.labels" . | nindent 4 }}
     service: keycloak

--- a/charts/launchpad/templates/ingress-launchpad.yaml
+++ b/charts/launchpad/templates/ingress-launchpad.yaml
@@ -2,6 +2,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "launchpad.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   labels:
     {{- include "launchpad.labels" . | nindent 4 }}
     service: launchpad

--- a/charts/launchpad/templates/secret-db.yaml
+++ b/charts/launchpad/templates/secret-db.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.dbSecretName }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 type: Opaque
 stringData:
   DB_HOST: "{{ .Values.postgresql.fullnameOverride }}"

--- a/charts/launchpad/templates/traefik-middleware-auth.yaml
+++ b/charts/launchpad/templates/traefik-middleware-auth.yaml
@@ -1,6 +1,8 @@
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   labels:
     application: launchpad
   name: {{ include "launchpad.name" . }}-auth-middleware

--- a/charts/launchpad/values.yaml
+++ b/charts/launchpad/values.yaml
@@ -64,6 +64,8 @@ LAUNCHPAD_INITIAL_CONFIG: >
 postgresql:
   enabled: true
   fullnameOverride: launchpad-db  # in real app will be f"launchpad-{apolo_app_id}-db"
+  commonAnnotations:
+    argocd.argoproj.io/sync-wave: "0"
   auth:
     existingSecret: launchpad-db-secret  # # in real app will be f"launchpad-{apolo_app_id}-db-secret"
     username: postgres
@@ -84,6 +86,8 @@ keycloak:
   defaultRealm: "master" # internal variable
   fullnameOverride: launchpad-keycloak  # in real app will be f"launchpad-{apolo_app_id}-keycloak"
   replicas: 1
+  commonAnnotations:
+    argocd.argoproj.io/sync-wave: "1"
   auth:
     adminUser: "admin"
     adminPassword: "Passw0rd!123"  # todo: should be passed as an arg?


### PR DESCRIPTION
Adding ArgoCD Sync Waves annotations to install each component in order.

Deployment Order

  1. Wave -1: Database secret is created first
  2. Wave 0: PostgreSQL starts and initializes databases
  3. Wave 1: Keycloak starts after PostgreSQL is ready (connects to keycloak DB)
  4. Wave 2: Launchpad application starts after both database and auth are ready
  5. Wave 3: All networking components (ingresses, middleware) deploy last

This ensures a clean dependency chain where each layer waits for the previous layer to be ready before starting, preventing  connection failures and startup issues.