### PR TITLE
Fix: using first user in postgres integration because it's never empty

### DIFF
--- a/launchpad/apps/registry/shared/openwebui.py
+++ b/launchpad/apps/registry/shared/openwebui.py
@@ -111,7 +111,7 @@ class OpenWebUIApp(App[OpenWebUIAppContext]):
                     "credentials": {
                         "type": "app-instance-ref",
                         "instance_id": str(self._context.postgres_app_id),
-                        "path": "$.postgres_users.users[1]",
+                        "path": "$.postgres_users.users[0]",
                     },
                 }
             },


### PR DESCRIPTION
Found the issue where Launchpad is trying to install OpenWebUI using user number 1 from Postgres outputs, but it's not guaranteed to exist. Using user number 0 because it is always created.

<img width="1210" height="730" alt="image" src="https://github.com/user-attachments/assets/92066ef5-d0a8-419c-bbaf-59680a0fd91e" />

Worked using "user 0":

<img width="800" height="575" alt="image" src="https://github.com/user-attachments/assets/67417ca0-8be0-421b-af58-d5284f9ecbde" />

