### PR TITLE
move middleware to app namespace + remove namespace from auth_middleware_name env var

### DIFF
--- a/charts/launchpad/templates/_helpers.tpl
+++ b/charts/launchpad/templates/_helpers.tpl
@@ -56,3 +56,7 @@ platform.apolo.us/component: app
 {{- define "launchpad.domainWithProtocol" -}}
 {{- printf "https://%s.%s" (include "launchpad.name" .) .Values.domain }}
 {{- end }}
+
+{{- define "launchpad.middlewareName" -}}
+{{- printf "%s-auth-middleware" (include "launchpad.name" .) }}
+{{- end }}

--- a/charts/launchpad/templates/deployment-launchpad.yaml
+++ b/charts/launchpad/templates/deployment-launchpad.yaml
@@ -72,7 +72,7 @@ spec:
             - name: BASE_DOMAIN
               value: {{ .Values.domain }}
             - name: AUTH_MIDDLEWARE_NAME
-              value: platform-{{ include "launchpad.name" . }}-auth-middleware
+              value: {{ include "launchpad.middlewareName" . }}
           {{- if .Values.resources }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/launchpad/templates/traefik-middleware-auth.yaml
+++ b/charts/launchpad/templates/traefik-middleware-auth.yaml
@@ -5,8 +5,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "3"
   labels:
     application: launchpad
-  name: {{ include "launchpad.name" . }}-auth-middleware
-  namespace: platform
+  name: {{ include "launchpad.middlewareName" . }}
 spec:
   forwardAuth:
     address: {{ include "launchpad.apiDomain" . }}/auth/authorize

--- a/charts/launchpad/values.yaml
+++ b/charts/launchpad/values.yaml
@@ -5,7 +5,7 @@ keycloakRealmImportConfigMapName: launchpad-keycloak-realm  # in real app will b
 
 image:
   repository: "ghcr.io/neuro-inc/launchpad"
-  tag: "25.9.12"
+  tag: "25.9.13"
 
 replicas: 1
 port: 8080


### PR DESCRIPTION
We currently cannot access OpenWebUI started with Launchpad because one if its ingress's middleware has the wrong name:

<img width="1234" height="150" alt="image" src="https://github.com/user-attachments/assets/17b3f899-afac-42a9-bcd9-3679a9ffec04" />


```
platform--apolo--demo--3a9bddab03a9fe2dc49aa9bd-platform-launchpad-4cfc564d13f2482f807e700e21780dd9-auth-middleware@kubernetescrd
```

This is formed by:

- App namespace `platform--apolo--demo--3a9bddab03a9fe2dc49aa9bd` - added by OpenWebUI install script ([here](https://github.com/neuro-inc/app-types/blob/d97938ce38c792bb2585835841929ea147937937/src/apolo_app_types/helm/apps/openwebui.py#L152)) since it expects the middleware to be in the same namespace as the app
- `platform` namespace added by [Launchpad ](https://github.com/neuro-inc/launchpad/blob/8e4c8248951c14b66c360d6c9974e55c53dad179/charts/launchpad/templates/deployment-launchpad.yaml#L75)app because it installs this middleware in that namespace
- m̀iddleware name `launchpad-4cfc564d13f2482f807e700e21780dd9-auth-middleware`

Solution:

- Move middleware from namespace  `platform` to `<app-namespace>`
- Remove the hardcoded `platform-` preffix from `AUTH_MIDDLEWARE_NAME` variable  - just pass middleware name since OpenWebUI assumes its in the same namespace