### PR TITLE
Add HTTPS to forwardAuth address and implement update_app_url function

### DIFF
--- a/charts/launchpad/templates/traefik-middleware-auth.yaml
+++ b/charts/launchpad/templates/traefik-middleware-auth.yaml
@@ -9,6 +9,6 @@ metadata:
   namespace: platform
 spec:
   forwardAuth:
-    address: {{ include "launchpad.apiDomain" . }}/auth/authorize
+    address: https://{{ include "launchpad.apiDomain" . }}/auth/authorize
     trustForwardHeader: true
     authResponseHeadersRegex: ^X-

--- a/launchpad/apps/storage.py
+++ b/launchpad/apps/storage.py
@@ -79,6 +79,24 @@ async def insert_app(
     return typing.cast(InstalledApp, installed_app)
 
 
+async def update_app_url(
+    db: AsyncSession,
+    app_id: UUID,
+    url: str,
+) -> InstalledApp | None:
+    """Update the URL of an installed app"""
+    from sqlalchemy import update
+    
+    query = (
+        update(InstalledApp)
+        .where(InstalledApp.app_id == app_id)
+        .values(url=url)
+        .returning(InstalledApp)
+    )
+    cursor = await db.execute(query)
+    return cursor.scalar_one_or_none()
+
+
 async def delete_app(
     db: AsyncSession,
     app_id: UUID,


### PR DESCRIPTION
# What this PR does:

- Fix issue with Traefik middleware that occurs when you don't add the protocol to `forwardAuth.address`. This causes a `500 error` when you try to access OpenWebUI

<img width="1246" height="74" alt="image" src="https://github.com/user-attachments/assets/531d4459-7b4e-408b-aa6b-d34d414e1996" />

- Fix issue where Launchpad won't save app output to database, so when `forwardAuth` middleware forwards to `/authorize` endpoint, [Launchpad doesn't find](https://github.com/neuro-inc/launchpad/blob/38b9d04c0ac0b2af535aaa4bf7aa68c43a4aa9a4/launchpad/auth/api.py#L30) the requested url in Installed Apps database :
<img width="1250" height="110" alt="image" src="https://github.com/user-attachments/assets/d901d1b7-75b5-4090-b9d9-fa936329e118" />

when we look at the database, there is no url in any app:

<img width="2560" height="207" alt="image" src="https://github.com/user-attachments/assets/af93c007-02a7-42a2-a307-e0ceaadc2637" />
