### PR TITLE
Include api domain in keycloak redirect urls

### DIFF
--- a/charts/launchpad/templates/_helpers.tpl
+++ b/charts/launchpad/templates/_helpers.tpl
@@ -49,6 +49,10 @@ platform.apolo.us/component: app
 {{- printf "%s-api.%s" (include "launchpad.name" .) .Values.domain }}
 {{- end }}
 
+{{- define "launchpad.apiDomainWithProtocol" -}}
+{{- printf "https://%s-api.%s" (include "launchpad.name" .) .Values.domain }}
+{{- end }}
+
 {{- define "keycloak.domain" -}}
 {{- printf "%s-keycloak.%s" (include "launchpad.name" .) .Values.domain }}
 {{- end }}

--- a/charts/launchpad/templates/configmap-keycloak-realm.yaml
+++ b/charts/launchpad/templates/configmap-keycloak-realm.yaml
@@ -706,7 +706,8 @@ data:
           "alwaysDisplayInConsole": false,
           "clientAuthenticatorType": "client-secret",
           "redirectUris": [
-            "{{ include "launchpad.domainWithProtocol" . }}/api/auth/callback/keycloak"
+            "{{ include "launchpad.domainWithProtocol" . }}/api/auth/callback/keycloak",
+            "{{ include "launchpad.apiDomainWithProtocol" . }}/auth/callback"
           ],
           "webOrigins": [
             {{ include "launchpad.domainWithProtocol" . | quote }}

--- a/charts/launchpad/templates/traefik-middleware-auth.yaml
+++ b/charts/launchpad/templates/traefik-middleware-auth.yaml
@@ -9,6 +9,6 @@ metadata:
   namespace: platform
 spec:
   forwardAuth:
-    address: https://{{ include "launchpad.apiDomain" . }}/auth/authorize
+    address: {{ include "launchpad.apiDomainWithProtocol" . }}/auth/authorize
     trustForwardHeader: true
     authResponseHeadersRegex: ^X-


### PR DESCRIPTION
When trying to access OpenWebUI app from Launchpad, the redirect url is different. 

<img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/030ccff4-ab9e-41c0-8ce4-ebc707e191b3" />


Added needed URL to Keycloak  `redirect_urls` .