### PR TITLE
Added /instances endpoint with admin auth to list installed apps

### DIFF
--- a/charts/launchpad/templates/_helpers.tpl
+++ b/charts/launchpad/templates/_helpers.tpl
@@ -64,3 +64,7 @@ platform.apolo.us/component: app
 {{- define "launchpad.netlify-configmap" -}}
 {{- printf "%s-netlify-configmap" (include "launchpad.name" .) }}
 {{- end }}
+
+{{- define "launchpad.admin-secret" -}}
+{{- printf "%s-admin-secret" (include "launchpad.name" .) }}
+{{- end }}

--- a/charts/launchpad/templates/admin-secret.yaml
+++ b/charts/launchpad/templates/admin-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "launchpad.admin-secret" . }}
+type: Opaque
+data:
+  LAUNCHPAD_ADMIN_PASSWORD: {{ .Values.LAUNCHPAD_ADMIN_PASSWORD | b64enc }}

--- a/charts/launchpad/templates/deployment-launchpad.yaml
+++ b/charts/launchpad/templates/deployment-launchpad.yaml
@@ -73,6 +73,8 @@ spec:
               value: {{ .Values.domain }}
             - name: AUTH_MIDDLEWARE_NAME
               value: platform-{{ include "launchpad.name" . }}-auth-middleware
+            - name: LAUNCHPAD_APP_ID
+              value: {{ .Values.apolo_app_id | quote }}
             - name: LAUNCHPAD_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/launchpad/templates/deployment-launchpad.yaml
+++ b/charts/launchpad/templates/deployment-launchpad.yaml
@@ -73,6 +73,11 @@ spec:
               value: {{ .Values.domain }}
             - name: AUTH_MIDDLEWARE_NAME
               value: platform-{{ include "launchpad.name" . }}-auth-middleware
+            - name: LAUNCHPAD_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "launchpad.admin-secret" . }}
+                  key: LAUNCHPAD_ADMIN_PASSWORD
           {{- if .Values.resources }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/launchpad/values.yaml
+++ b/charts/launchpad/values.yaml
@@ -5,7 +5,7 @@ keycloakRealmImportConfigMapName: launchpad-keycloak-realm  # in real app will b
 
 image:
   repository: "ghcr.io/neuro-inc/launchpad"
-  tag: "25.9.14"
+  tag: "25.9.15"
 
 replicas: 1
 port: 8080
@@ -24,6 +24,8 @@ labels:
 
 podLabels: {}
 podAnnotations: {}
+
+# LAUNCHPAD_ADMIN_PASSWORD: null  # should be set to a secure value in real app
 
 # application specific values example
 LAUNCHPAD_INITIAL_CONFIG: >

--- a/launchpad/api.py
+++ b/launchpad/api.py
@@ -7,8 +7,10 @@ from starlette.responses import Response
 
 from launchpad.app import Launchpad
 from launchpad.apps.api import apps_router
+from launchpad.apps.models import InstalledApp
+from launchpad.apps.service import DepAppService
 from launchpad.auth.api import auth_router
-from launchpad.auth.dependencies import auth_required
+from launchpad.auth.dependencies import auth_required, admin_auth_required
 
 root_router = APIRouter()
 
@@ -39,3 +41,10 @@ async def view_get_config(request: Request) -> dict[str, Any]:
             "realm": app.config.keycloak.realm,
         }
     }
+
+
+@root_router.get("/instances", dependencies=[Depends(admin_auth_required)])
+async def view_get_instances(
+    app_service: DepAppService,
+) -> list[InstalledApp]:
+    return await app_service.list_installed_apps()

--- a/launchpad/apps/service.py
+++ b/launchpad/apps/service.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Annotated
 from uuid import UUID
 
+import backoff
 from fastapi import Depends
 from starlette.requests import Request
 
@@ -46,6 +47,7 @@ class AppService:
     def __init__(self, app: Launchpad):
         self._db = app.db
         self._apps_api_client = app.apps_api_client
+        self._instance_id = app.config.instance_id
 
     async def get_installed_app(
         self,
@@ -109,6 +111,46 @@ class AppService:
         app = await self._app_from_request(request, launchpad_app_name)
         return await self.install(app=app)
 
+    @backoff.on_exception(
+        wait_gen=backoff.expo,
+        exception=(
+            AppServiceError,
+            AppsApiError,
+        ),
+        max_tries=5,
+    )
+    async def _append_app_to_outputs(
+        self,
+        app: InstalledApp,
+    ) -> None:
+        if self._instance_id is None:
+            raise AppServiceError("Instance ID is not configured")
+
+        outputs = await self._apps_api_client.get_outputs(self._instance_id)
+        if outputs is None:
+            raise AppServiceError("Failed to get current outputs")
+
+        installed_apps = outputs.get("installed_apps", [])
+        installed_apps.append(
+            {
+                "app_id": str(app.app_id),
+                "app_name": app.app_name,
+            }
+        )
+
+        outputs["installed_apps"] = installed_apps
+
+        try:
+            await self._apps_api_client.update_outputs(
+                self._instance_id,
+                outputs,
+            )
+        except AppsApiError as e:
+            logger.error(
+                f"Failed to update outputs for instance {self._instance_id}: {e}"
+            )
+            raise AppServiceError("Failed to update instance outputs") from e
+
     async def install(
         self,
         app: T_App,
@@ -128,7 +170,7 @@ class AppService:
                         "Internal service error. "
                         "Please try again later, or contact support"
                     )
-                return await insert_app(
+                installed_app = await insert_app(
                     db=db,
                     app_id=installation_response["id"],
                     app_name=installation_response["name"],
@@ -138,6 +180,10 @@ class AppService:
                     user_id=None,
                     url=None,
                 )
+
+                await self._append_app_to_outputs(installed_app)
+
+                return installed_app
 
     async def delete(self, app_id: UUID) -> None:
         await self._apps_api_client.delete_app(app_id)

--- a/launchpad/apps/service.py
+++ b/launchpad/apps/service.py
@@ -131,12 +131,15 @@ class AppService:
             raise AppServiceError("Failed to get current outputs")
 
         installed_apps = outputs.get("installed_apps", [])
-        installed_apps.append(
-            {
-                "app_id": str(app.app_id),
-                "app_name": app.app_name,
-            }
-        )
+        if app.app_id not in [
+            UUID(a["app_id"]) for a in installed_apps if "app_id" in a
+        ]:
+            installed_apps.append(
+                {
+                    "app_id": str(app.app_id),
+                    "app_name": app.app_name,
+                }
+            )
 
         outputs["installed_apps"] = installed_apps
 

--- a/launchpad/config.py
+++ b/launchpad/config.py
@@ -6,6 +6,7 @@ from base64 import b64decode
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 from dotenv import load_dotenv
 from yarl import URL
@@ -66,6 +67,7 @@ class Config:
     apolo: ApoloConfig
     apps: AppsConfig
     server: ServerConfig = ServerConfig()
+    instance_id: UUID | None = None
 
 
 class EnvironConfigFactory:
@@ -84,7 +86,14 @@ class EnvironConfigFactory:
             apolo=self.create_apolo(),
             apps=self.create_apps(),
             postgres=self.create_postgres(),
+            instance_id=self.get_instance_id(),
         )
+
+    def get_instance_id(self) -> UUID | None:
+        instance_id = self._environ.get("LAUNCHPAD_APP_ID")
+        if instance_id is None:
+            return None
+        return UUID(instance_id)
 
     def create_server(self) -> ServerConfig:
         return ServerConfig(

--- a/launchpad/ext/apps_api.py
+++ b/launchpad/ext/apps_api.py
@@ -119,3 +119,14 @@ class AppsApiClient:
         except ValueError as e:
             logger.error(f"Bad response: {raw_response}")
             raise AppsApiError() from e
+
+    async def update_outputs(
+        self,
+        app_id: UUID,
+        outputs: dict[str, Any],
+    ) -> None:
+        await self._request(
+            method="POST",
+            url=f"{self.v1_url}/instances/{app_id}/output",
+            json={"output": outputs},
+        )

--- a/tests/unit/test_apps_service.py
+++ b/tests/unit/test_apps_service.py
@@ -9,12 +9,15 @@ from launchpad.app import Launchpad
 from launchpad.apps.models import InstalledApp
 from launchpad.apps.registry.base import App
 from launchpad.apps.service import AppService
+from launchpad.config import Config
 from launchpad.ext.apps_api import AppsApiClient
 
 
 @pytest.fixture
 def mock_apps_api_client() -> AsyncMock:
-    return AsyncMock(spec=AppsApiClient)
+    apps_api = AsyncMock(spec=AppsApiClient)
+    apps_api.get_outputs.return_value = {}
+    return apps_api
 
 
 @pytest.fixture
@@ -36,6 +39,8 @@ def mock_launchpad_app(
     app = MagicMock(spec=Launchpad)
     app.apps_api_client = mock_apps_api_client
     app.db = mock_db_session_maker
+    app.config = MagicMock(spec=Config)
+    app.config.instance_id = uuid.uuid4()
     return app
 
 
@@ -56,6 +61,8 @@ async def test_app_service_install_app_success(
     app_id: UUID,
 ) -> None:
     mock_app_instance = MagicMock(spec=App)  # Corrected to spec=App
+    mock_app_instance.config = MagicMock(spec=Config)
+    mock_app_instance.config.instance_id = "INSTANCE_ID"
     mock_app_instance.to_apps_api_payload.return_value = {
         "name": "test-app",
         "chart": "test-chart",


### PR DESCRIPTION
This PR:

- creates a secret `launchpad-<id>-admin-secret` with a password that is mounted into the application in `LAUNCHPAD_ADMIN_PASSWORD`
- creates an endpoint `/instances` that:
  - uses this  `LAUNCHPAD_ADMIN_PASSWORD` for authentication
  - returns a list of installed apps

This endpoint will be used by App-Types `get_outputs` method to get the `instance-id` of all installed apps so we can uninstall them when Launchpad is uninstalled.