### PR TITLE
Custom app installation

### DIFF
--- a/.apolo/applications.yaml
+++ b/.apolo/applications.yaml
@@ -5,13 +5,13 @@
   helm_path: "charts/launchpad"
   app_package_name: apolo_apps_launchpad
   inputs:
-    schema_path: .apolo/src/apolo_apps_launchpad/schemas/LaunchpadInputs.json
-    types_name: LaunchpadInputs
-    processor: LaunchpadInputsProcessor
+    schema_path: .apolo/src/apolo_apps_launchpad/schemas/LaunchpadAppInputs.json
+    types_name: LaunchpadAppInputs
+    processor: LaunchpadAppInputsProcessor
     image: ghcr.io/neuro-inc/launchpad
   outputs:
-    schema_path: .apolo/src/apolo_apps_launchpad/schemas/LaunchpadOutputs.json
-    types_name: LaunchpadOutputs
+    schema_path: .apolo/src/apolo_apps_launchpad/schemas/LaunchpadAppOutputs.json
+    types_name: LaunchpadAppOutputs
     processor: LaunchpadOutputProcessor
     image: ghcr.io/neuro-inc/launchpad
   short_description: "Preconfigured applications for the Apolo platform"

--- a/.apolo/applications.yaml
+++ b/.apolo/applications.yaml
@@ -7,7 +7,7 @@
   inputs:
     schema_path: .apolo/src/apolo_apps_launchpad/schemas/LaunchpadAppInputs.json
     types_name: LaunchpadAppInputs
-    processor: LaunchpadAppInputsProcessor
+    processor: LaunchpadInputsProcessor
     image: ghcr.io/neuro-inc/launchpad
   outputs:
     schema_path: .apolo/src/apolo_apps_launchpad/schemas/LaunchpadAppOutputs.json

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [master]
     tags: ["v*"]
+  pull_request:
+    branches: [master]
 
 env:
   IMAGE_NAME: "launchpad"
@@ -43,3 +45,43 @@ jobs:
         run: |
           docker tag ${{ env.IMAGE_NAME }}:latest ghcr.io/neuro-inc/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           docker push ghcr.io/neuro-inc/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+
+  release-pr-image:
+    name: Release PR image
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout commit
+        uses: actions/checkout@v4
+
+      - name: Set image tag from PR
+        run: |
+          # Use PR number as tag
+          echo IMAGE_TAG=pr-${{ github.event.pull_request.number }} >> $GITHUB_ENV
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build image
+        run: |
+          docker build -t ${{ env.IMAGE_NAME }}:latest -f Dockerfile .
+
+      - name: Push PR image
+        run: |
+          docker tag ${{ env.IMAGE_NAME }}:latest ghcr.io/neuro-inc/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          docker push ghcr.io/neuro-inc/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🐳 Docker image for this PR has been built and pushed:\n\n\`ghcr.io/neuro-inc/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}\``
+            })

--- a/launchpad/apps/models.py
+++ b/launchpad/apps/models.py
@@ -1,7 +1,9 @@
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.dialects.postgresql import JSON
 
 from launchpad.db.base import Base
 
@@ -35,3 +37,30 @@ class InstalledApp(Base):
     """
     user_id: Mapped[str | None]
     url: Mapped[str | None]
+    template_name: Mapped[str]
+    """Template name used for installation
+    """
+    template_version: Mapped[str]
+    """Template version used for installation
+    """
+    verbose_name: Mapped[str]
+    """User-friendly display name
+    """
+    description_short: Mapped[str]
+    """Short description of the app
+    """
+    description_long: Mapped[str]
+    """Long description of the app
+    """
+    logo: Mapped[str]
+    """URL to the app's logo
+    """
+    documentation_urls: Mapped[list[dict[str, str]]] = mapped_column(JSON)
+    """List of documentation URLs
+    """
+    external_urls: Mapped[list[dict[str, str]]] = mapped_column(JSON)
+    """List of external URLs
+    """
+    tags: Mapped[list[str]] = mapped_column(JSON)
+    """List of tags for categorization
+    """

--- a/launchpad/apps/registry/__init__.py
+++ b/launchpad/apps/registry/__init__.py
@@ -1,4 +1,4 @@
-from launchpad.apps.registry.base import App
+from launchpad.apps.registry.base import App, GenericApp
 from launchpad.apps.registry.internal.context import InternalAppContext
 from launchpad.apps.registry.internal.embeddings import (
     EmbeddingsApp,
@@ -15,7 +15,7 @@ from launchpad.apps.registry.shared.openwebui import (
     OpenWebUIAppContext,
 )
 
-T_App = OpenWebUIApp | App[InternalAppContext]
+T_App = OpenWebUIApp | App[InternalAppContext] | GenericApp
 
 APPS: dict[str, type[T_App]] = {
     APP_NAME_LLM_INFERENCE: LlmInferenceApp,

--- a/launchpad/apps/registry/base.py
+++ b/launchpad/apps/registry/base.py
@@ -63,3 +63,65 @@ class App(ABC, Generic[T_Context]):
     @abstractmethod
     async def _generate_inputs(self) -> dict[str, Any]:
         raise NotImplementedError()
+
+
+class GenericApp(App[BaseContext]):
+    """
+    A generic app class that can be instantiated with any template and inputs.
+    This allows for dynamic app installation without defining specific app classes.
+    """
+
+    def __init__(
+        self,
+        template_name: str,
+        template_version: str,
+        inputs: dict[str, Any],
+        name: str | None = None,
+        is_internal: bool = False,
+        is_shared: bool = True,
+        verbose_name: str = "",
+        description_short: str = "",
+        description_long: str = "",
+        logo: str = "",
+        documentation_urls: list[dict[str, str]] | None = None,
+        external_urls: list[dict[str, str]] | None = None,
+        tags: list[str] | None = None,
+    ):
+        """
+        Initialize a generic app.
+
+        Args:
+            template_name: The name of the template to use for installation
+            template_version: The version of the template
+            inputs: The inputs to pass to the Apps API
+            name: Optional name for the app (defaults to template_name)
+            is_internal: Whether the app is internal (not visible to end users)
+            is_shared: Whether the app can be shared by multiple users
+            verbose_name: User-friendly name for the app
+            description_short: Short description of the app
+            description_long: Long description of the app
+            logo: URL to the app's logo
+            documentation_urls: List of documentation URLs
+            external_urls: List of external URLs
+            tags: List of tags for categorization
+        """
+        # Create a minimal context since we don't need complex context for generic apps
+        context = BaseContext()
+        super().__init__(context)
+
+        self.name = name or template_name
+        self.template_name = template_name
+        self.template_version = template_version
+        self._inputs = inputs
+        self.is_internal = is_internal
+        self.is_shared = is_shared
+        self.verbose_name = verbose_name or template_name
+        self.description_short = description_short
+        self.description_long = description_long
+        self.logo = logo
+        self.documentation_urls = documentation_urls or []
+        self.external_urls = external_urls or []
+        self.tags = tags or []
+
+    async def _generate_inputs(self) -> dict[str, Any]:
+        return self._inputs

--- a/launchpad/apps/resources.py
+++ b/launchpad/apps/resources.py
@@ -1,4 +1,23 @@
-from pydantic import BaseModel, Field, ConfigDict
+from typing import Any
+from pydantic import BaseModel, Field, ConfigDict, model_validator
+
+
+class GenericAppInstallRequest(BaseModel):
+    """Request model for installing a generic app with custom configuration"""
+
+    template_name: str = Field(..., description="Name of the template to install")
+    template_version: str = Field(..., description="Version of the template")
+    inputs: dict[str, Any] = Field(..., description="Inputs to pass to the Apps API")
+    name: str | None = Field(None, description="Custom name for the app (defaults to template_name)")
+    verbose_name: str | None = Field(None, description="User-friendly display name")
+    description_short: str = Field(default="", description="Short description")
+    description_long: str = Field(default="", description="Long description")
+    logo: str = Field(default="", description="URL to the app's logo")
+    documentation_urls: list[dict[str, str]] = Field(default_factory=list, description="Documentation URLs")
+    external_urls: list[dict[str, str]] = Field(default_factory=list, description="External URLs")
+    tags: list[str] = Field(default_factory=list, description="Tags for categorization")
+    is_internal: bool = Field(default=False, description="Whether app is internal")
+    is_shared: bool = Field(default=True, description="Whether app can be shared")
 
 
 class LaunchpadAppRead(BaseModel):

--- a/launchpad/apps/storage.py
+++ b/launchpad/apps/storage.py
@@ -48,6 +48,15 @@ async def insert_app(
     is_shared: bool,
     user_id: str | None,
     url: str | None,
+    template_name: str,
+    template_version: str,
+    verbose_name: str,
+    description_short: str,
+    description_long: str,
+    logo: str,
+    documentation_urls: list[dict[str, str]],
+    external_urls: list[dict[str, str]],
+    tags: list[str],
 ) -> InstalledApp:
     query = (
         insert(InstalledApp)
@@ -61,6 +70,15 @@ async def insert_app(
                 is_shared=is_shared,
                 user_id=user_id,
                 url=url,
+                template_name=template_name,
+                template_version=template_version,
+                verbose_name=verbose_name,
+                description_short=description_short,
+                description_long=description_long,
+                logo=logo,
+                documentation_urls=documentation_urls,
+                external_urls=external_urls,
+                tags=tags,
             )
         )
         # possible update a URL of an app
@@ -70,6 +88,15 @@ async def insert_app(
                 app_id=app_id,
                 app_name=app_name,
                 url=url,
+                template_name=template_name,
+                template_version=template_version,
+                verbose_name=verbose_name,
+                description_short=description_short,
+                description_long=description_long,
+                logo=logo,
+                documentation_urls=documentation_urls,
+                external_urls=external_urls,
+                tags=tags,
             ),
         )
         .returning(InstalledApp)

--- a/tests/unit/test_apps_service.py
+++ b/tests/unit/test_apps_service.py
@@ -70,6 +70,15 @@ async def test_app_service_install_app_success(
     mock_app_instance.name = "test-app-name"
     mock_app_instance.is_internal = False
     mock_app_instance.is_shared = False
+    mock_app_instance.template_name = "test-template"
+    mock_app_instance.template_version = "1.0.0"
+    mock_app_instance.verbose_name = "Test App"
+    mock_app_instance.description_short = "Short description"
+    mock_app_instance.description_long = "Long description"
+    mock_app_instance.logo = "http://example.com/logo.png"
+    mock_app_instance.documentation_urls = []
+    mock_app_instance.external_urls = []
+    mock_app_instance.tags = []
 
     mock_apps_api_client.install_app.return_value = {
         "id": "123",
@@ -87,6 +96,15 @@ async def test_app_service_install_app_success(
             is_shared=False,
             user_id=None,
             url=None,
+            template_name="test-template",
+            template_version="1.0.0",
+            verbose_name="Test App",
+            description_short="Short description",
+            description_long="Long description",
+            logo="http://example.com/logo.png",
+            documentation_urls=[],
+            external_urls=[],
+            tags=[],
         )
 
         result = await app_service.install(

--- a/tests/unit/test_apps_storage.py
+++ b/tests/unit/test_apps_storage.py
@@ -57,6 +57,15 @@ async def test_insert_app_success(mock_db_session: MagicMock, app_id: UUID) -> N
         "is_shared": False,
         "user_id": "test-user",
         "url": "http://test.com",
+        "template_name": "test-template",
+        "template_version": "1.0.0",
+        "verbose_name": "Test App",
+        "description_short": "Short description",
+        "description_long": "Long description",
+        "logo": "http://example.com/logo.png",
+        "documentation_urls": [],
+        "external_urls": [],
+        "tags": [],
     }
     mock_db_session.add.return_value = None
     mock_db_session.flush.return_value = None
@@ -71,6 +80,15 @@ async def test_insert_app_success(mock_db_session: MagicMock, app_id: UUID) -> N
         is_shared=app_data["is_shared"],
         user_id=app_data["user_id"],
         url=app_data["url"],
+        template_name=app_data["template_name"],
+        template_version=app_data["template_version"],
+        verbose_name=app_data["verbose_name"],
+        description_short=app_data["description_short"],
+        description_long=app_data["description_long"],
+        logo=app_data["logo"],
+        documentation_urls=app_data["documentation_urls"],
+        external_urls=app_data["external_urls"],
+        tags=app_data["tags"],
     )
 
     result = await insert_app(mock_db_session, **app_data)


### PR DESCRIPTION
Enables installing custom "generic" apps through the API by sending an app template and inputs. It also enables overriding the app's name and description for the UI.

This should enable adding any app to Launchpad UI after it is already running. The idea is that Apolo Solutions guys will be able to install Service Deployment (or any other) apps using Launchpad API.