### PR TITLE
fix: scope auth cookie to specific launchpad instance domain

### DIFF
--- a/.apolo/src/apolo_apps_launchpad/inputs_processor.py
+++ b/.apolo/src/apolo_apps_launchpad/inputs_processor.py
@@ -3,6 +3,7 @@ import os
 import random
 import string
 import typing as t
+from urllib.parse import urlparse
 
 import apolo_sdk
 from apolo_app_types import LLMInputs, TextEmbeddingsInferenceAppInputs
@@ -76,6 +77,22 @@ mkdir -p "/opt/bitnami/keycloak/themes/apolo"
 cp -R "/tmp/repo/keycloak-theme/apolo/." "/opt/bitnami/keycloak/themes/apolo/"
 chown -R 1001:0 /opt/bitnami/keycloak/themes
 """
+
+
+def _normalize_netlify_domain(preview_ui_url: str) -> str:
+    normalized = preview_ui_url.strip()
+    if not normalized:
+        raise ValueError("Preview UI URL is required when 'Use Preview UI' is enabled.")
+
+    if "://" not in normalized:
+        normalized = f"https://{normalized}"
+
+    parsed = urlparse(normalized)
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("Preview UI URL must be a valid hostname or full https URL.")
+
+    return hostname
 
 
 def _generate_password(length: int = PASSWORD_DEFAULT_LENGTH) -> str:
@@ -491,6 +508,10 @@ class LaunchpadInputsProcessor(BaseChartValueProcessor[LaunchpadAppInputs]):
         cluster_config = self.client.config.clusters[self.client.cluster_name]
         if cluster_config.apps.launchpad_use_subdomain:
             values["clientSubdomain"] = True
+        if input_.launchpad_web_app_config.use_preview_ui:
+            values["netlifyDomain"] = _normalize_netlify_domain(
+                input_.launchpad_web_app_config.preview_ui_url or ""
+            )
 
         return {
             **values,

--- a/.apolo/src/apolo_apps_launchpad/schemas/LaunchpadAppInputs.json
+++ b/.apolo/src/apolo_apps_launchpad/schemas/LaunchpadAppInputs.json
@@ -548,6 +548,33 @@
           "$ref": "#/$defs/Preset",
           "x-description": "Preset to use for the Launchpad application. Minimal resources: 0.5 CPU cores, 1 GiB memory.",
           "x-title": "Launchpad Preset"
+        },
+        "use_preview_ui": {
+          "default": false,
+          "title": "Use Preview Ui",
+          "type": "boolean",
+          "x-description": "Use a Launchpad Web UI preview build instead of the regular UI.",
+          "x-is-advanced-field": true,
+          "x-is-configurable": true,
+          "x-meta-type": "inline",
+          "x-title": "Use Preview UI"
+        },
+        "preview_ui_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "https://deploy-preview-120--launchpad-web-ui-dev-apolo-us.netlify.app",
+          "title": "Preview Ui Url",
+          "x-description": "Paste the full Launchpad Web UI preview URL. You can replace the prefilled value with any other preview URL.",
+          "x-is-advanced-field": true,
+          "x-is-configurable": true,
+          "x-meta-type": "inline",
+          "x-title": "Preview UI URL"
         }
       },
       "required": [

--- a/.apolo/src/apolo_apps_launchpad/types.py
+++ b/.apolo/src/apolo_apps_launchpad/types.py
@@ -349,6 +349,29 @@ class LaunchpadWebAppConfig(AbstractAppFieldType):
             "Minimal resources: 0.5 CPU cores, 1 GiB memory.",
         ).as_json_schema_extra(),
     )
+    use_preview_ui: bool = Field(
+        default=False,
+        json_schema_extra=SchemaExtraMetadata(
+            title="Use Preview UI",
+            description=(
+                "Use a Launchpad Web UI preview build instead of the regular UI."
+            ),
+            is_advanced_field=True,
+        ).as_json_schema_extra(),
+    )
+    preview_ui_url: str | None = Field(
+        default=(
+            "https://deploy-preview-120--launchpad-web-ui-dev-apolo-us.netlify.app"
+        ),
+        json_schema_extra=SchemaExtraMetadata(
+            title="Preview UI URL",
+            description=(
+                "Paste the full Launchpad Web UI preview URL. "
+                "You can replace the prefilled value with any other preview URL."
+            ),
+            is_advanced_field=True,
+        ).as_json_schema_extra(),
+    )
 
 
 class KeycloakConfig(AbstractAppFieldType):

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,7 +157,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Purge old artifacts
-        uses: kolpav/purge-artifacts-action@v2
+        uses: kolpav/purge-artifacts-action@v1
         with:
           token: ${{ github.token }}
           expire-in: 30mins
@@ -252,7 +252,7 @@ jobs:
       - name: Checkout commit
         uses: actions/checkout@v6
       - name: Purge old artifacts
-        uses: kolpav/purge-artifacts-action@v2
+        uses: kolpav/purge-artifacts-action@v1
         with:
           token: ${{ github.token }}
           expire-in: 30mins

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,7 +159,7 @@ jobs:
       - name: Purge old artifacts
         uses: kolpav/purge-artifacts-action@v2
         with:
-          token: [REDACTED:API key param] github.token }}
+          token: ${{ github.token }}
           expire-in: 30mins
 
       - name: Login to ghcr.io
@@ -254,7 +254,7 @@ jobs:
       - name: Purge old artifacts
         uses: kolpav/purge-artifacts-action@v2
         with:
-          token: [REDACTED:API key param] github.token }}
+          token: ${{ github.token }}
           expire-in: 30mins
       - name: Set APP_IMAGE_TAG
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
         run: make test-hooks
 
       - name: Upload unit test coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         if: always()
         with:
           files: .coverage.unit.xml
@@ -101,7 +101,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload integration test coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         if: always()
         with:
           files: .coverage.integration.xml
@@ -111,7 +111,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload hooks test coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         if: always()
         with:
           files: hooks/.coverage.hooks.xml
@@ -134,7 +134,7 @@ jobs:
     - name: metadata
       id: metadata
       if: github.actor == 'dependabot[bot]'
-      uses: dependabot/fetch-metadata@v2
+      uses: dependabot/fetch-metadata@v3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Enable auto-merge for bot PRs
@@ -210,7 +210,7 @@ jobs:
           make push-image
 
       - name: Comment on PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const branchName = '${{ github.head_ref }}';

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,9 +157,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Purge old artifacts
-        uses: kolpav/purge-artifacts-action@v1
+        uses: kolpav/purge-artifacts-action@v2
         with:
-          token: ${{ github.token }}
+          token: [REDACTED:API key param] github.token }}
           expire-in: 30mins
 
       - name: Login to ghcr.io
@@ -252,9 +252,9 @@ jobs:
       - name: Checkout commit
         uses: actions/checkout@v6
       - name: Purge old artifacts
-        uses: kolpav/purge-artifacts-action@v1
+        uses: kolpav/purge-artifacts-action@v2
         with:
-          token: ${{ github.token }}
+          token: [REDACTED:API key param] github.token }}
           expire-in: 30mins
       - name: Set APP_IMAGE_TAG
         run: |

--- a/hooks/tests/unit/test_launchpad_input_generation.py
+++ b/hooks/tests/unit/test_launchpad_input_generation.py
@@ -1029,3 +1029,58 @@ async def test_launchpad_values_generation__subdomain(
     )
 
     assert helm_params["clientSubdomain"] is True
+
+
+@pytest.mark.asyncio
+async def test_launchpad_values_generation__preview_ui_override(apolo_client):
+    processor = LaunchpadInputsProcessor(client=apolo_client)
+    helm_params = await processor.gen_extra_values(
+        input_=LaunchpadAppInputs(
+            launchpad_web_app_config=LaunchpadWebAppConfig(
+                preset=Preset(name="cpu-medium"),
+                use_preview_ui=True,
+                preview_ui_url=(
+                    "https://deploy-preview-120--"
+                    "launchpad-web-ui-dev-apolo-us.netlify.app"
+                ),
+            ),
+            apps_config=AppsConfig(
+                quick_start_config=NoQuickStartConfig(no_quickstart=True),
+            ),
+        ),
+        app_name="launchpad-app",
+        namespace="default-namespace",
+        app_secrets_name=APP_SECRETS_NAME,
+        app_id=APP_ID,
+    )
+
+    assert (
+        helm_params["netlifyDomain"]
+        == "deploy-preview-120--launchpad-web-ui-dev-apolo-us.netlify.app"
+    )
+
+
+@pytest.mark.asyncio
+async def test_launchpad_values_generation__preview_ui_requires_url(apolo_client):
+    processor = LaunchpadInputsProcessor(client=apolo_client)
+
+    with pytest.raises(
+        ValueError,
+        match="Preview UI URL is required when 'Use Preview UI' is enabled.",
+    ):
+        await processor.gen_extra_values(
+            input_=LaunchpadAppInputs(
+                launchpad_web_app_config=LaunchpadWebAppConfig(
+                    preset=Preset(name="cpu-medium"),
+                    use_preview_ui=True,
+                    preview_ui_url="",
+                ),
+                apps_config=AppsConfig(
+                    quick_start_config=NoQuickStartConfig(no_quickstart=True),
+                ),
+            ),
+            app_name="launchpad-app",
+            namespace="default-namespace",
+            app_secrets_name=APP_SECRETS_NAME,
+            app_id=APP_ID,
+        )

--- a/hooks/tests/unit/test_launchpad_input_generation.py
+++ b/hooks/tests/unit/test_launchpad_input_generation.py
@@ -1084,3 +1084,57 @@ async def test_launchpad_values_generation__preview_ui_requires_url(apolo_client
             app_secrets_name=APP_SECRETS_NAME,
             app_id=APP_ID,
         )
+
+
+@pytest.mark.asyncio
+async def test_launchpad_values_generation__preview_ui_accepts_hostname(apolo_client):
+    processor = LaunchpadInputsProcessor(client=apolo_client)
+    helm_params = await processor.gen_extra_values(
+        input_=LaunchpadAppInputs(
+            launchpad_web_app_config=LaunchpadWebAppConfig(
+                preset=Preset(name="cpu-medium"),
+                use_preview_ui=True,
+                preview_ui_url="deploy-preview-120--launchpad-web-ui-dev-apolo-us.netlify.app",
+            ),
+            apps_config=AppsConfig(
+                quick_start_config=NoQuickStartConfig(no_quickstart=True),
+            ),
+        ),
+        app_name="launchpad-app",
+        namespace="default-namespace",
+        app_secrets_name=APP_SECRETS_NAME,
+        app_id=APP_ID,
+    )
+
+    assert (
+        helm_params["netlifyDomain"]
+        == "deploy-preview-120--launchpad-web-ui-dev-apolo-us.netlify.app"
+    )
+
+
+@pytest.mark.asyncio
+async def test_launchpad_values_generation__preview_ui_rejects_invalid_url(
+    apolo_client,
+):
+    processor = LaunchpadInputsProcessor(client=apolo_client)
+
+    with pytest.raises(
+        ValueError,
+        match="Preview UI URL must be a valid hostname or full https URL.",
+    ):
+        await processor.gen_extra_values(
+            input_=LaunchpadAppInputs(
+                launchpad_web_app_config=LaunchpadWebAppConfig(
+                    preset=Preset(name="cpu-medium"),
+                    use_preview_ui=True,
+                    preview_ui_url="https://",
+                ),
+                apps_config=AppsConfig(
+                    quick_start_config=NoQuickStartConfig(no_quickstart=True),
+                ),
+            ),
+            app_name="launchpad-app",
+            namespace="default-namespace",
+            app_secrets_name=APP_SECRETS_NAME,
+            app_id=APP_ID,
+        )

--- a/launchpad/auth/oauth.py
+++ b/launchpad/auth/oauth.py
@@ -37,7 +37,6 @@ class Oauth:
         self,
         http: ClientSession,
         keycloak_config: KeycloakConfig,
-        cookie_domain: str,
         launchpad_domain: str,
         scope: list[str] | None = None,
     ):
@@ -45,7 +44,7 @@ class Oauth:
         self._url = keycloak_config.url
         self._realm = keycloak_config.realm
         self._client_id = keycloak_config.client_id
-        self._cookie_domain = f".{cookie_domain}"
+        self._cookie_domain = launchpad_domain
         self._launchpad_domain = launchpad_domain
         self._callback_url = f"https://{self._launchpad_domain}/auth/callback"
         self._keycloak_url = f"{self._url}/realms/{self._realm}/protocol/openid-connect"

--- a/launchpad/auth/oauth.py
+++ b/launchpad/auth/oauth.py
@@ -38,6 +38,7 @@ class Oauth:
         http: ClientSession,
         keycloak_config: KeycloakConfig,
         launchpad_domain: str,
+        legacy_cookie_domain: str | None = None,
         scope: list[str] | None = None,
     ):
         self._http = http
@@ -45,6 +46,9 @@ class Oauth:
         self._realm = keycloak_config.realm
         self._client_id = keycloak_config.client_id
         self._cookie_domain = launchpad_domain
+        self._legacy_cookie_domains = self._build_legacy_cookie_domains(
+            legacy_cookie_domain
+        )
         self._launchpad_domain = launchpad_domain
         self._callback_url = f"https://{self._launchpad_domain}/auth/callback"
         self._keycloak_url = f"{self._url}/realms/{self._realm}/protocol/openid-connect"
@@ -79,6 +83,7 @@ class Oauth:
         )
 
         response = RedirectResponse(url=auth_url)
+        self._clear_legacy_cookies(response)
         self._set_cookie(response, key=COOKIE_CODE_VERIFIER, value=code_verifier)
         return response
 
@@ -105,6 +110,7 @@ class Oauth:
         access_token = await self._fetch_token(data)
 
         response = RedirectResponse(original_url)
+        self._clear_legacy_cookies(response)
         self.set_auth_cookie(response, access_token)
         return response
 
@@ -114,9 +120,8 @@ class Oauth:
     def logout(self, response: Response) -> None:
         """Cleanup of cookies on logout"""
         for cookie in (COOKIE_TOKEN, COOKIE_CODE_VERIFIER):
-            response.delete_cookie(
-                key=cookie, domain=self._cookie_domain, secure=True, httponly=True
-            )
+            self._delete_cookie(response, key=cookie, domain=self._cookie_domain)
+        self._clear_legacy_cookies(response)
 
     @backoff.on_exception(
         wait_gen=backoff.expo,
@@ -148,6 +153,31 @@ class Oauth:
             key=key,
             value=value,
             domain=self._cookie_domain,
+            secure=True,
+            httponly=True,
+        )
+
+    @staticmethod
+    def _build_legacy_cookie_domains(domain: str | None) -> tuple[str, ...]:
+        if not domain:
+            return ()
+
+        normalized = domain.lstrip(".")
+        if not normalized:
+            return ()
+
+        return (normalized, f".{normalized}")
+
+    def _clear_legacy_cookies(self, response: Response) -> None:
+        for cookie in (COOKIE_TOKEN, COOKIE_CODE_VERIFIER):
+            for domain in self._legacy_cookie_domains:
+                self._delete_cookie(response, key=cookie, domain=domain)
+
+    @staticmethod
+    def _delete_cookie(response: Response, key: str, domain: str) -> None:
+        response.delete_cookie(
+            key=key,
+            domain=domain,
             secure=True,
             httponly=True,
         )

--- a/launchpad/lifespan.py
+++ b/launchpad/lifespan.py
@@ -54,6 +54,7 @@ async def lifespan(app: Launchpad) -> t.AsyncIterator[None]:
             http=app.http,
             keycloak_config=app.config.keycloak,
             launchpad_domain=app.config.apolo.self_domain,
+            legacy_cookie_domain=app.config.apolo.base_domain,
         )
 
         # Seed app templates and initialize internal apps only if apps config is present

--- a/launchpad/lifespan.py
+++ b/launchpad/lifespan.py
@@ -53,7 +53,6 @@ async def lifespan(app: Launchpad) -> t.AsyncIterator[None]:
         app.oauth = Oauth(
             http=app.http,
             keycloak_config=app.config.keycloak,
-            cookie_domain=app.config.apolo.base_domain,
             launchpad_domain=app.config.apolo.self_domain,
         )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -282,7 +282,6 @@ def mock_http_and_oauth(
     oauth = Oauth(
         http=mock_http,
         keycloak_config=mock_config_auth.keycloak,
-        cookie_domain=mock_config_auth.apolo.base_domain,
         launchpad_domain=mock_config_auth.apolo.self_domain,
     )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -283,6 +283,7 @@ def mock_http_and_oauth(
         http=mock_http,
         keycloak_config=mock_config_auth.keycloak,
         launchpad_domain=mock_config_auth.apolo.self_domain,
+        legacy_cookie_domain=mock_config_auth.apolo.base_domain,
     )
 
     return mock_http, oauth

--- a/tests/integration/test_auth_set_cookie.py
+++ b/tests/integration/test_auth_set_cookie.py
@@ -62,7 +62,6 @@ def oauth(mock_http: AsyncMock, mock_config: Config) -> Oauth:
     return Oauth(
         http=mock_http,
         keycloak_config=mock_config.keycloak,
-        cookie_domain=mock_config.apolo.base_domain,
         launchpad_domain=mock_config.apolo.self_domain,
     )
 

--- a/tests/integration/test_auth_set_cookie.py
+++ b/tests/integration/test_auth_set_cookie.py
@@ -63,6 +63,7 @@ def oauth(mock_http: AsyncMock, mock_config: Config) -> Oauth:
         http=mock_http,
         keycloak_config=mock_config.keycloak,
         launchpad_domain=mock_config.apolo.self_domain,
+        legacy_cookie_domain=mock_config.apolo.base_domain,
     )
 
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -45,7 +45,6 @@ def oauth_instance(
     return Oauth(
         http=mock_http_session,
         keycloak_config=mock_keycloak_config,
-        cookie_domain="mock-cookie.com",
         launchpad_domain="mock-launchpad.com",
     )
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,14 +1,15 @@
+import base64
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import ClientResponseError, ClientSession
 from starlette.requests import Request
-from starlette.responses import RedirectResponse
+from starlette.responses import RedirectResponse, Response
 from yarl import URL
 
 from launchpad.auth.dependencies import auth_required
 from launchpad.auth.models import User
-from launchpad.auth.oauth import COOKIE_CODE_VERIFIER, Oauth, OauthError
+from launchpad.auth.oauth import COOKIE_CODE_VERIFIER, COOKIE_TOKEN, Oauth, OauthError
 from launchpad.config import KeycloakConfig
 from launchpad.errors import Unauthorized
 
@@ -46,6 +47,7 @@ def oauth_instance(
         http=mock_http_session,
         keycloak_config=mock_keycloak_config,
         launchpad_domain="mock-launchpad.com",
+        legacy_cookie_domain="mock-base.com",
     )
 
 
@@ -132,8 +134,11 @@ async def test_oauth_redirect(oauth_instance: Oauth, mock_request: MagicMock) ->
     assert "code_challenge" in redirect_url.query
     assert "state" in redirect_url.query
 
-    # Verify cookie
-    assert COOKIE_CODE_VERIFIER in response.headers["set-cookie"]
+    set_cookies = response.headers.getlist("set-cookie")
+    assert any(COOKIE_CODE_VERIFIER in header for header in set_cookies)
+    assert any('launchpad-token=""' in header for header in set_cookies)
+    assert any("Domain=mock-base.com" in header for header in set_cookies)
+    assert any("Domain=.mock-base.com" in header for header in set_cookies)
 
 
 async def test_oauth_callback_missing_params(
@@ -156,6 +161,44 @@ async def test_oauth_callback_missing_params(
     mock_request.cookies = {}
     with pytest.raises(OauthError, match="missing required params"):
         await oauth_instance.callback(mock_request)
+
+
+async def test_oauth_callback_clears_legacy_cookies(
+    oauth_instance: Oauth, mock_request: MagicMock
+) -> None:
+    original_redirect_uri = "https://original.com/path"
+    mock_request.query_params = {
+        "code": "mock-code",
+        "state": base64.urlsafe_b64encode(original_redirect_uri.encode()).decode(),
+    }
+    mock_request.cookies = {COOKIE_CODE_VERIFIER: "mock-code-verifier"}
+
+    with patch.object(
+        oauth_instance, "_fetch_token", new=AsyncMock(return_value="access-token")
+    ):
+        response = await oauth_instance.callback(mock_request)
+
+    assert response.headers["location"] == original_redirect_uri
+    set_cookies = response.headers.getlist("set-cookie")
+    assert any(f"{COOKIE_TOKEN}=access-token" in header for header in set_cookies)
+    assert any("Domain=mock-launchpad.com" in header for header in set_cookies)
+    assert any('launchpad-token=""' in header for header in set_cookies)
+    assert any('code_verifier=""' in header for header in set_cookies)
+    assert any("Domain=mock-base.com" in header for header in set_cookies)
+    assert any("Domain=.mock-base.com" in header for header in set_cookies)
+
+
+def test_oauth_logout_clears_host_and_legacy_cookies(oauth_instance: Oauth) -> None:
+    response = Response()
+
+    oauth_instance.logout(response)
+
+    set_cookies = response.headers.getlist("set-cookie")
+    assert any("Domain=mock-launchpad.com" in header for header in set_cookies)
+    assert any("Domain=mock-base.com" in header for header in set_cookies)
+    assert any("Domain=.mock-base.com" in header for header in set_cookies)
+    assert any('launchpad-token=""' in header for header in set_cookies)
+    assert any('code_verifier=""' in header for header in set_cookies)
 
 
 async def test_oauth_fetch_token_client_error(


### PR DESCRIPTION
## Summary

- All launchpad instances previously set the `launchpad-token` cookie on the parent domain (`.apps.dev.org.apolo.us`), causing browsers to send it to every `*.apps.dev.org.apolo.us` subdomain
- When a user visited instance B, their browser sent a JWT token issued by instance A's Keycloak — resulting in a KID mismatch (`unable to match a KID between a token and a JWKS`), 401 errors, and a redirect loop that timed out Netlify edge functions
- Fix: scope the cookie to `SELF_DOMAIN` (the exact host of this launchpad instance) so cookies are never shared between instances

## Changes

- `launchpad/auth/oauth.py` — removed `cookie_domain` parameter; `_cookie_domain` now uses `launchpad_domain` (exact host) instead of wildcard parent domain
- `launchpad/lifespan.py` — removed `cookie_domain=app.config.apolo.base_domain` from `Oauth(...)` constructor call
- `tests/unit/test_auth.py` — removed `cookie_domain` from test fixture

## Test plan

- [ ] All unit tests pass (`pytest tests/unit/test_auth.py` — 9/9)
- [ ] Log in to one launchpad instance, then open a second instance in the same browser — no KID mismatch error
- [ ] Netlify edge function no longer times out on the affected domain